### PR TITLE
Add support for iOS 16 and older

### DIFF
--- a/ToDoCalendar/ToDoCalendar.MauiHybrid/Platforms/iOS/Info.plist
+++ b/ToDoCalendar/ToDoCalendar.MauiHybrid/Platforms/iOS/Info.plist
@@ -28,6 +28,8 @@
     </array>
     <key>XSAppIconAssets</key>
     <string>Assets.xcassets/appicon.appiconset</string>
+    <key>NSCalendarsUsageDescription</key>
+    <string>This app requires full access to your calendars to create, update, and delete events.</string>
     <key>NSCalendarsFullAccessUsageDescription</key>
     <string>This app requires full access to your calendars to create, update, and delete events.</string>
     <key>NSCalendarsWriteOnlyAccessUsageDescription</key>


### PR DESCRIPTION
Without this fix, the app would crash as soon as it tries to read the calendar events