### PR TITLE
Use LocalDateTime for macOS Calendar Events

### DIFF
--- a/ToDoCalendar/ToDoCalendar.MauiHybrid/Services/CalendarService.cs
+++ b/ToDoCalendar/ToDoCalendar.MauiHybrid/Services/CalendarService.cs
@@ -23,7 +23,7 @@ public class CalendarService : ICalendarService
                 Id = x.Id,
                 Title = x.Title,
                 Description = x.Description,
-                DateTime = x.StartDate.DateTime
+                DateTime = x.StartDate.LocalDateTime
             };
 
             if (calendars.TryGetValue(x.CalendarId, out var calendar))
@@ -65,7 +65,7 @@ public class CalendarService : ICalendarService
         await ExecuteOnMainThread(async () =>
         {
             var existingEvent = await _calendarStore.GetEvent(calendarEvent.Id);
-            var dateOffset = new DateTimeOffset(DateTime.SpecifyKind(calendarEvent.DateTime, DateTimeKind.Utc));
+            var dateOffset = new DateTimeOffset(DateTime.SpecifyKind(calendarEvent.DateTime, DateTimeKind.Local));
 
             await _calendarStore.UpdateEvent(
                 calendarEvent.Id,

--- a/ToDoCalendar/ToDoCalendarControl/MainControl.xaml.cs
+++ b/ToDoCalendar/ToDoCalendarControl/MainControl.xaml.cs
@@ -163,22 +163,29 @@ namespace ToDoCalendarControl
             // Show again the button to add new events:
             ButtonsOuterContainer.Visibility = Visibility.Visible;
 
-            // If the event has an empty title and was created recently (less than 3 minues ago),
-            // then delete it (because it was most likely created by mistake), otherwise save the new title:
-            if (string.IsNullOrEmpty(EventOptionsControl.EventModel.Title)
-                && (EventOptionsControl.EventModel.TemporaryCreationDate.HasValue
-                && EventOptionsControl.EventModel.TemporaryCreationDate.Value < DateTime.UtcNow
-                && (DateTime.UtcNow - EventOptionsControl.EventModel.TemporaryCreationDate.Value) < TimeSpan.FromMinutes(3)))
+            try
             {
-                await _controller.DeleteEvent(EventOptionsControl.EventModel, EventOptionsControl.DayModel, EventOptionsControl.Day);
-            }
-            else
-            {
-                if (EventOptionsControl.EventModel.Title != EventOptionsControl.PreviousTitle &&
-                    _controller.CalendarService is ICalendarService calendarService)
+                // If the event has an empty title and was created recently (less than 3 minues ago),
+                // then delete it (because it was most likely created by mistake), otherwise save the new title:
+                if (string.IsNullOrEmpty(EventOptionsControl.EventModel.Title)
+                    && (EventOptionsControl.EventModel.TemporaryCreationDate.HasValue
+                    && EventOptionsControl.EventModel.TemporaryCreationDate.Value < DateTime.UtcNow
+                    && (DateTime.UtcNow - EventOptionsControl.EventModel.TemporaryCreationDate.Value) < TimeSpan.FromMinutes(3)))
                 {
-                    await calendarService.UpdateCalendarEvent(new DeviceEvent(EventOptionsControl.EventModel, EventOptionsControl.Day));
+                    await _controller.DeleteEvent(EventOptionsControl.EventModel, EventOptionsControl.DayModel, EventOptionsControl.Day);
                 }
+                else
+                {
+                    if (EventOptionsControl.EventModel.Title != EventOptionsControl.PreviousTitle &&
+                        _controller.CalendarService is ICalendarService calendarService)
+                    {
+                        await calendarService.UpdateCalendarEvent(new DeviceEvent(EventOptionsControl.EventModel, EventOptionsControl.Day));
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(ex.ToString(), "Cannot update the event");
             }
         }
 


### PR DESCRIPTION
macOS system calendars (e.g., public holidays) store events in different timezones, but their DateTime values are already adjusted to local time. The previous implementation didn’t explicitly use local time, which could cause inconsistencies.

Fix: Updated GetCalendarEvents to use x.StartDate.LocalDateTime, ensuring correct local timezone handling.